### PR TITLE
Add support for exclusionary text filters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/ULogViewer/bin/Debug/net7.0/ULogViewer.dll",
+            "program": "${workspaceFolder}/ULogViewer/bin/Debug/net8.0/ULogViewer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/ULogViewer",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -22,7 +22,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-Windows",
-            "program": "${workspaceFolder}/ULogViewer/bin/Debug-Windows/net7.0-windows10.0.17763.0/ULogViewer.dll",
+            "program": "${workspaceFolder}/ULogViewer/bin/Debug-Windows/net8.0-windows10.0.17763.0/ULogViewer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/ULogViewer",
             "console": "internalConsole",
@@ -33,7 +33,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-macOS-arm64",
-            "program": "${workspaceFolder}/ULogViewer/bin/Debug/net7.0/osx.11.0-arm64/ULogViewer.dll",
+            "program": "${workspaceFolder}/ULogViewer/bin/Debug/net8.0/osx.11.0-arm64/ULogViewer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/ULogViewer",
             "console": "internalConsole",
@@ -44,7 +44,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-TextShellHost",
-            "program": "${workspaceFolder}/TextShellHost/bin/Debug/net7.0/TextShellHost.dll",
+            "program": "${workspaceFolder}/TextShellHost/bin/Debug/net8.0/TextShellHost.dll",
             "args": [
             ],
             "cwd": "${workspaceFolder}/TextShellHost",

--- a/ULogViewer/ViewModels/LogFilteringViewModel.cs
+++ b/ULogViewer/ViewModels/LogFilteringViewModel.cs
@@ -393,6 +393,8 @@ class LogFilteringViewModel : SessionComponent
 
         // setup text regex
         var textRegexList = new List<Regex>();
+        var exclusionRegexList = new List<Regex>();
+        
         var textFilter = this.TextFilter;
         if (textFilter is not null)
         {
@@ -417,11 +419,25 @@ class LogFilteringViewModel : SessionComponent
             }
             textRegexList.Add(textFilter);
         }
+
+        // In the predefinedTextFilters, look for those with name starting with '!'
+        // These will be treated as exclude filters rather than include filters
         foreach (var filter in this.predefinedTextFilters)
-            textRegexList.Add(filter.Regex);
+        {
+            if ((filter.Name ?? "").StartsWith("!"))
+            {
+                exclusionRegexList.Add(filter.Regex);
+            } 
+            else
+            {
+                textRegexList.Add(filter.Regex);
+            }
+        }
         this.logFilter.TextRegexList = textRegexList;
+        this.logFilter.ExclusionTextRegexList = exclusionRegexList;
+
         this.DisplayableLogGroup?.Let(it =>
-            it.ActiveTextFilters = textRegexList);
+            it.ActiveTextFilters = textRegexList); //leave exclusionary filters out of this
 
         // print log
         if (this.Application.IsDebugMode)
@@ -430,7 +446,8 @@ class LogFilteringViewModel : SessionComponent
             this.Logger.LogDebug("  Level: {level}", this.logFilter.Level);
             this.Logger.LogDebug("  PID: {pid}", this.logFilter.ProcessId.Let(pid => pid.HasValue ? pid.ToString() : "Null"));
             this.Logger.LogDebug("  TID: {tid}", this.logFilter.ThreadId.Let(tid => tid.HasValue ? tid.ToString() : "Null"));
-            this.Logger.LogDebug("  Text filters: {textRegexListCount}", textRegexList.Count);
+            this.Logger.LogDebug("  Text inclusion filters: {textRegexListCount}", textRegexList.Count);
+            this.Logger.LogDebug("  Text exclusion filters: {exclRegexListCount}", exclusionRegexList.Count);
         }
 
         // cancel temporarily shown logs


### PR DESCRIPTION
This PR implements exclusionary text filters. The text filters that ULogViewer lets users create today are what I call 'inclusionary' - meaning if any one of the selected filter-pattens match then the log entry is displayed
An exclusionary text filter is the opposite - if any of the exclusionary filter-patterns match then the log is not displayed.
Useful for things like "Show me all logs except if it has 'foo' or 'bar'"  

Right now the way to create an exclusionary text filter is to prefix the name with ‘!’ character. I recognize this is crude but it helped me get it working quickly.
 I can see a future change being to add a control in the text filter creation editor to mark something as “exclusionary” or not, rather than keying off the name.

Example:
If my log file is this
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/71ec8b95-4116-4a70-8f10-08b5fec2e4f5">

I can select !Foo predefined pattern and it will exclude anything with Foo
<img width="1335" alt="image" src="https://github.com/user-attachments/assets/4f074541-cb26-4e2d-b5d4-f8b98f815c8d">

If I select both !Foo and !Cat it will exlude both but show everything else:
<img width="1337" alt="image" src="https://github.com/user-attachments/assets/5d747ac0-2aa9-4724-ba6e-97707f68e2fd">

Note there is nothing special about !Foo and !Cat - they have the patterns Foo and Cat respectively. I've just named them with '!' at the start and the program treats them as exclusionary patterns
<img width="490" alt="image" src="https://github.com/user-attachments/assets/436a254d-429a-4c78-ac11-6e4741967066">


